### PR TITLE
Remove unneeded code and add VStack to preview

### DIFF
--- a/ImageTest/TestOne.swift
+++ b/ImageTest/TestOne.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct TestOne: View {
     @ObservedObject var player: Player
     @State private var deck: Deck
-    @State private var changed = false
     
     init(player: Player, deck: Deck) {
         self.player = player
@@ -27,14 +26,12 @@ struct TestOne: View {
                     ForEach(player.hand) { card in
                         
                         CardView(image: card.image)
-                            .transition(.offset(x: changed ? 50 : 0, y: 0))
-                            .animation(.easeInOut(duration: 0.5), value: changed)
+                            .transition(.offset(x: 50, y: 0))
                     }
             }
             Button(action: {
                 withAnimation(.easeInOut(duration: 0.5)){
                     player.receiveCard(card: deck.deal()!)
-                    changed.toggle()
                 }
             }) {
                 Text("Hit")
@@ -45,6 +42,8 @@ struct TestOne: View {
 
 struct TestOne_Previews: PreviewProvider {
     static var previews: some View {
-        TestOne(player: Player(), deck: Deck(numberOfDecks: 6))
+        VStack {
+            TestOne(player: Player(), deck: Deck(numberOfDecks: 6))
+        }
     }
 }


### PR DESCRIPTION
Apparently there is a bug in preview with transitions. Embedding the preview in a VStack allows you to see the transition animation working.